### PR TITLE
fix #2 NullPointerException on metered methods with complex signatures

### DIFF
--- a/envs/se/src/main/java/org/stefanutti/metrics/aspectj/se/ComplexSignatureMethod.java
+++ b/envs/se/src/main/java/org/stefanutti/metrics/aspectj/se/ComplexSignatureMethod.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (C) 2013 Antonin Stefanutti (antonin.stefanutti@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.stefanutti.metrics.aspectj.se;
+
+import com.codahale.metrics.annotation.ExceptionMetered;
+import com.codahale.metrics.annotation.Metered;
+import com.codahale.metrics.annotation.Timed;
+import org.stefanutti.metrics.aspectj.Metrics;
+import org.stefanutti.metrics.aspectj.Registry;
+
+import java.util.List;
+
+@Metrics
+@Registry("complexSignatureRegistry")
+public class ComplexSignatureMethod {
+
+    @Timed
+    public static <T> T timedStaticMethod(T first, List<T> second, T... third) throws NullPointerException, IllegalStateException {
+        return first;
+    }
+
+    @Metered
+    public static <T> T meteredStaticMethod(T first, List<T> second, T... third) throws NullPointerException, IllegalStateException {
+        return first;
+    }
+
+    @ExceptionMetered
+    public static <T> T exceptionMeteredStaticMethod(T first, List<T> second, T... third) throws NullPointerException, IllegalStateException {
+        return first;
+    }
+
+    @Timed
+    public <T> T timedMethod(T first, List<T> second, T... third) throws NullPointerException, IllegalStateException {
+        return first;
+    }
+
+    @Metered
+    public <T> T meteredMethod(T first, List<T> second, T... third) throws NullPointerException, IllegalStateException {
+        return first;
+    }
+
+    @ExceptionMetered
+    public <T> T exceptionMeteredMethod(T first, List<T> second, T... third) throws NullPointerException, IllegalStateException {
+        return first;
+    }
+}

--- a/envs/se/src/test/java/org/stefanutti/metrics/aspectj/se/ComplexSignatureMethodTest.java
+++ b/envs/se/src/test/java/org/stefanutti/metrics/aspectj/se/ComplexSignatureMethodTest.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (C) 2013 Antonin Stefanutti (antonin.stefanutti@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.stefanutti.metrics.aspectj.se;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.SharedMetricRegistries;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ComplexSignatureMethodTest {
+
+    private MetricRegistry registry = SharedMetricRegistries.getOrCreate("complexSignatureRegistry");
+    private ComplexSignatureMethod instance = new ComplexSignatureMethod();
+
+    @Before
+    public  void before() {
+        assertEquals("Not all metrics were registered", 6, registry.getMetrics().size());
+    }
+
+    @Test
+    public void callMeteredStaticMethodOnce() {
+        ComplexSignatureMethod.meteredStaticMethod(null, null);
+    }
+
+    @Test
+    public void callTimedStaticMethodOnce() {
+        ComplexSignatureMethod.timedStaticMethod(null, null);
+    }
+
+    @Test
+    public void callExceptionMeteredStaticMethodOnce() {
+        ComplexSignatureMethod.exceptionMeteredStaticMethod(null, null);
+    }
+
+    @Test
+    public void callTimedMethodOnce() {
+        instance.timedMethod(null, null);
+    }
+
+    @Test
+    public void callMeteredMethodOnce() {
+        instance.meteredMethod(null, null);
+    }
+
+    @Test
+    public void callExceptionMeteredMethodOnce() {
+        instance.exceptionMeteredMethod(null, null);
+    }
+}

--- a/impl/src/main/aspect/org/stefanutti/metrics/aspectj/ExceptionMeteredAspect.aj
+++ b/impl/src/main/aspect/org/stefanutti/metrics/aspectj/ExceptionMeteredAspect.aj
@@ -17,13 +17,15 @@ package org.stefanutti.metrics.aspectj;
 
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.annotation.ExceptionMetered;
+import org.aspectj.lang.reflect.MethodSignature;
 
 final aspect ExceptionMeteredAspect {
 
     pointcut exceptionMetered(Profiled object) : execution(@ExceptionMetered !static * (@Metrics Profiled+).*(..)) && this(object);
 
     after(Profiled object) throwing (Throwable throwable) : exceptionMetered(object) {
-        AnnotatedMetric metric = object.metrics.get(thisJoinPointStaticPart.getSignature().toLongString());
+        String methodSignature = ((MethodSignature) thisJoinPointStaticPart.getSignature()).getMethod().toString();
+        AnnotatedMetric metric = object.metrics.get(methodSignature);
         if (metric.getAnnotation(ExceptionMetered.class).cause().isInstance(throwable)) {
             metric.getMetric(Meter.class).mark();
         }

--- a/impl/src/main/aspect/org/stefanutti/metrics/aspectj/ExceptionMeteredStaticAspect.aj
+++ b/impl/src/main/aspect/org/stefanutti/metrics/aspectj/ExceptionMeteredStaticAspect.aj
@@ -17,13 +17,15 @@ package org.stefanutti.metrics.aspectj;
 
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.annotation.ExceptionMetered;
+import org.aspectj.lang.reflect.MethodSignature;
 
 final aspect ExceptionMeteredStaticAspect {
 
     pointcut exceptionMetered() : execution(@ExceptionMetered static * (@Metrics *).*(..));
 
     after() throwing (Throwable throwable) : exceptionMetered() {
-        AnnotatedMetric metric = MetricStaticAspect.metrics.get(thisJoinPointStaticPart.getSignature().toLongString());
+        String methodSignature = ((MethodSignature) thisJoinPointStaticPart.getSignature()).getMethod().toString();
+        AnnotatedMetric metric = MetricStaticAspect.metrics.get(methodSignature);
         if (metric.getAnnotation(ExceptionMetered.class).cause().isInstance(throwable)) {
             metric.getMetric(Meter.class).mark();
         }

--- a/impl/src/main/aspect/org/stefanutti/metrics/aspectj/MeteredAspect.aj
+++ b/impl/src/main/aspect/org/stefanutti/metrics/aspectj/MeteredAspect.aj
@@ -17,13 +17,15 @@ package org.stefanutti.metrics.aspectj;
 
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.annotation.Metered;
+import org.aspectj.lang.reflect.MethodSignature;
 
 final aspect MeteredAspect {
 
     pointcut metered(Profiled object) : execution(@Metered !static * (@Metrics Profiled+).*(..)) && this(object);
 
     before(Profiled object) : metered(object) {
-        Meter meter = object.metrics.get(thisJoinPointStaticPart.getSignature().toLongString()).getMetric(Meter.class);
+        String methodSignature = ((MethodSignature) thisJoinPointStaticPart.getSignature()).getMethod().toString();
+        Meter meter = object.metrics.get(methodSignature).getMetric(Meter.class);
         meter.mark();
     }
 }

--- a/impl/src/main/aspect/org/stefanutti/metrics/aspectj/MeteredStaticAspect.aj
+++ b/impl/src/main/aspect/org/stefanutti/metrics/aspectj/MeteredStaticAspect.aj
@@ -17,13 +17,15 @@ package org.stefanutti.metrics.aspectj;
 
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.annotation.Metered;
+import org.aspectj.lang.reflect.MethodSignature;
 
 final aspect MeteredStaticAspect {
 
     pointcut metered() : execution(@Metered static * (@Metrics *).*(..));
 
     before() : metered() {
-        Meter meter = MetricStaticAspect.metrics.get(thisJoinPointStaticPart.getSignature().toLongString()).getMetric(Meter.class);
+        String methodSignature = ((MethodSignature) thisJoinPointStaticPart.getSignature()).getMethod().toString();
+        Meter meter = MetricStaticAspect.metrics.get(methodSignature).getMetric(Meter.class);
         meter.mark();
     }
 }

--- a/impl/src/main/aspect/org/stefanutti/metrics/aspectj/TimedAspect.aj
+++ b/impl/src/main/aspect/org/stefanutti/metrics/aspectj/TimedAspect.aj
@@ -17,13 +17,15 @@ package org.stefanutti.metrics.aspectj;
 
 import com.codahale.metrics.Timer;
 import com.codahale.metrics.annotation.Timed;
+import org.aspectj.lang.reflect.MethodSignature;
 
 final aspect TimedAspect {
 
     pointcut timed(Profiled object) : execution(@Timed !static * (@Metrics Profiled+).*(..)) && this(object);
 
     Object around(Profiled object) : timed(object) {
-        Timer timer = object.metrics.get(thisJoinPointStaticPart.getSignature().toLongString()).getMetric(Timer.class);
+        String methodSignature = ((MethodSignature) thisJoinPointStaticPart.getSignature()).getMethod().toString();
+        Timer timer = object.metrics.get(methodSignature).getMetric(Timer.class);
         Timer.Context context = timer.time();
         try {
             return proceed(object);

--- a/impl/src/main/aspect/org/stefanutti/metrics/aspectj/TimedStaticAspect.aj
+++ b/impl/src/main/aspect/org/stefanutti/metrics/aspectj/TimedStaticAspect.aj
@@ -17,13 +17,15 @@ package org.stefanutti.metrics.aspectj;
 
 import com.codahale.metrics.Timer;
 import com.codahale.metrics.annotation.Timed;
+import org.aspectj.lang.reflect.MethodSignature;
 
 final aspect TimedStaticAspect {
 
     pointcut timed() : execution(@Timed static * (@Metrics *).*(..));
 
     Object around() : timed() {
-        Timer timer = MetricStaticAspect.metrics.get(thisJoinPointStaticPart.getSignature().toLongString()).getMetric(Timer.class);
+        String methodSignature = ((MethodSignature) thisJoinPointStaticPart.getSignature()).getMethod().toString();
+        Timer timer = MetricStaticAspect.metrics.get(methodSignature).getMetric(Timer.class);
         Timer.Context context = timer.time();
         try {
             return proceed();


### PR DESCRIPTION
Method signatures for metrics resolution were determined by different means in different places in code. This led to errors for methods with several parameters, exceptions, generics, etc.
This commit forces common method signature resolution.
