### PR TITLE
Fix IllegalAccessError

### DIFF
--- a/impl/src/main/java/org/stefanutti/metrics/aspectj/AnnotatedMetric.java
+++ b/impl/src/main/java/org/stefanutti/metrics/aspectj/AnnotatedMetric.java
@@ -19,7 +19,7 @@ import com.codahale.metrics.Metric;
 
 import java.lang.annotation.Annotation;
 
-/* packaged-private */ interface AnnotatedMetric<T extends Metric> {
+public interface AnnotatedMetric<T extends Metric> {
 
     boolean isPresent();
 


### PR DESCRIPTION
I was getting the following exception while using the latest SNAPSHOT from source:

```
java.lang.IllegalAccessError: tried to access class org.stefanutti.metrics.aspectj.AnnotatedMetric from class com.clarecontrols.licensing.cliq.service.impl.FusionAPIImpl
! at com.clarecontrols.licensing.cliq.service.impl.FusionAPIImpl.ping_aroundBody3$advice(FusionAPIImpl.java:28) ~[license-server-1.0.1-SNAPSHOT.jar:1.0.1-SNAPSHOT]
! at com.clarecontrols.licensing.cliq.service.impl.FusionAPIImpl.ping(FusionAPIImpl.java:1) ~[license-server-1.0.1-SNAPSHOT.jar:1.0.1-SNAPSHOT]
! at com.clarecontrols.licensing.cliq.health.FusionAPIHealthCheck.check(FusionAPIHealthCheck.java:26) ~[license-server-1.0.1-SNAPSHOT.jar:1.0.1-SNAPSHOT]
! at com.codahale.metrics.health.HealthCheck.execute(HealthCheck.java:172) ~[license-server-1.0.1-SNAPSHOT.jar:1.0.1-SNAPSHOT]
! at com.codahale.metrics.health.HealthCheckRegistry.runHealthChecks(HealthCheckRegistry.java:77) ~[license-server-1.0.1-SNAPSHOT.jar:1.0.1-SNAPSHOT]
! at com.codahale.metrics.servlets.HealthCheckServlet.runHealthChecks(HealthCheckServlet.java:120) ~[license-server-1.0.1-SNAPSHOT.jar:1.0.1-SNAPSHOT]
! at com.codahale.metrics.servlets.HealthCheckServlet.doGet(HealthCheckServlet.java:89) ~[license-server-1.0.1-SNAPSHOT.jar:1.0.1-SNAPSHOT]
! at javax.servlet.http.HttpServlet.service(HttpServlet.java:735) ~[license-server-1.0.1-SNAPSHOT.jar:1.0.1-SNAPSHOT]
! at javax.servlet.http.HttpServlet.service(HttpServlet.java:848) ~[license-server-1.0.1-SNAPSHOT.jar:1.0.1-SNAPSHOT]
! at com.codahale.metrics.servlets.AdminServlet.service(AdminServlet.java:94) ~[license-server-1.0.1-SNAPSHOT.jar:1.0.1-SNAPSHOT]
! at javax.servlet.http.HttpServlet.service(HttpServlet.java:848) ~[license-server-1.0.1-SNAPSHOT.jar:1.0.1-SNAPSHOT]
! at io.dropwizard.jetty.NonblockingServletHolder.handle(NonblockingServletHolder.java:49) ~[license-server-1.0.1-SNAPSHOT.jar:1.0.1-SNAPSHOT]
! at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1515) ~[license-server-1.0.1-SNAPSHOT.jar:1.0.1-SNAPSHOT]
! at io.dropwizard.jersey.filter.AllowedMethodsFilter.handle(AllowedMethodsFilter.java:44) ~[license-server-1.0.1-SNAPSHOT.jar:1.0.1-SNAPSHOT]
! at io.dropwizard.jersey.filter.AllowedMethodsFilter.doFilter(AllowedMethodsFilter.java:39) ~[license-server-1.0.1-SNAPSHOT.jar:1.0.1-SNAPSHOT]
! at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1486) ~[license-server-1.0.1-SNAPSHOT.jar:1.0.1-SNAPSHOT]
! at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:519) [license-server-1.0.1-SNAPSHOT.jar:1.0.1-SNAPSHOT]
! at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1097) [license-server-1.0.1-SNAPSHOT.jar:1.0.1-SNAPSHOT]
! at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:448) [license-server-1.0.1-SNAPSHOT.jar:1.0.1-SNAPSHOT]
! at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1031) [license-server-1.0.1-SNAPSHOT.jar:1.0.1-SNAPSHOT]
! at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:136) [license-server-1.0.1-SNAPSHOT.jar:1.0.1-SNAPSHOT]
! at io.dropwizard.jetty.RoutingHandler.handle(RoutingHandler.java:51) [license-server-1.0.1-SNAPSHOT.jar:1.0.1-SNAPSHOT]
! at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:97) [license-server-1.0.1-SNAPSHOT.jar:1.0.1-SNAPSHOT]
! at org.eclipse.jetty.server.handler.RequestLogHandler.handle(RequestLogHandler.java:92) [license-server-1.0.1-SNAPSHOT.jar:1.0.1-SNAPSHOT]
! at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:97) [license-server-1.0.1-SNAPSHOT.jar:1.0.1-SNAPSHOT]
! at org.eclipse.jetty.server.handler.StatisticsHandler.handle(StatisticsHandler.java:162) [license-server-1.0.1-SNAPSHOT.jar:1.0.1-SNAPSHOT]
! at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:97) [license-server-1.0.1-SNAPSHOT.jar:1.0.1-SNAPSHOT]
! at org.eclipse.jetty.server.Server.handle(Server.java:446) [license-server-1.0.1-SNAPSHOT.jar:1.0.1-SNAPSHOT]
! at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:271) [license-server-1.0.1-SNAPSHOT.jar:1.0.1-SNAPSHOT]
! at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:246) [license-server-1.0.1-SNAPSHOT.jar:1.0.1-SNAPSHOT]
! at org.eclipse.jetty.io.AbstractConnection$ReadCallback.run(AbstractConnection.java:358) [license-server-1.0.1-SNAPSHOT.jar:1.0.1-SNAPSHOT]
! at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:601) [license-server-1.0.1-SNAPSHOT.jar:1.0.1-SNAPSHOT]
! at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:532) [license-server-1.0.1-SNAPSHOT.jar:1.0.1-SNAPSHOT]
! at java.lang.Thread.run(Thread.java:745) [na:1.8.0_05]
```

Making `AnnotatedMetric` public instead of package visible solved the issue.
