### PR TITLE
Updating metrics dependencies to resolve classloader conflicts

### DIFF
--- a/deps/pom.xml
+++ b/deps/pom.xml
@@ -20,7 +20,7 @@
                     <createSourcesJar>true</createSourcesJar>
                     <artifactSet>
                         <excludes>
-                            <exclude>com.codahale.metrics:metrics-core</exclude>
+                            <exclude>io.dropwizard.metrics:metrics-core</exclude>
                             <exclude>org.slf4j:slf4j-api</exclude>
                         </excludes>
                     </artifactSet>

--- a/envs/pom.xml
+++ b/envs/pom.xml
@@ -29,7 +29,7 @@
             </properties>
             <dependencies>
                 <dependency>
-                    <groupId>com.codahale.metrics</groupId>
+                    <groupId>io.dropwizard.metrics</groupId>
                     <artifactId>metrics-core</artifactId>
                 </dependency>
                 <dependency>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -41,12 +41,12 @@
         <!-- compile dependencies -->
 
         <dependency>
-            <groupId>com.codahale.metrics</groupId>
+            <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>com.codahale.metrics</groupId>
+            <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-annotation</artifactId>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <metrics.version>3.0.2</metrics.version>
+        <metrics.version>3.1.2</metrics.version>
         <aspectj.version>1.8.7</aspectj.version>
     </properties>
 
@@ -190,13 +190,13 @@
             <!-- compile dependencies -->
 
             <dependency>
-                <groupId>com.codahale.metrics</groupId>
+                <groupId>io.dropwizard.metrics</groupId>
                 <artifactId>metrics-core</artifactId>
                 <version>${metrics.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>com.codahale.metrics</groupId>
+                <groupId>io.dropwizard.metrics</groupId>
                 <artifactId>metrics-annotation</artifactId>
                 <version>${metrics.version}</version>
                 <exclusions>


### PR DESCRIPTION
The Dropwizard metrics library has changed the group name of their maven artifacts from com.codahale.metrics to io.dropwizard.metrics.  I've been running into classloader issues by having both jars on the classpath.